### PR TITLE
fixed bug in isVector* methods

### DIFF
--- a/Math/Tuple.php
+++ b/Math/Tuple.php
@@ -60,7 +60,7 @@ class Math_Tuple
      */
     public function squeezeHoles()
     {
-        $this->data = explode(":", implode(":",$this->data));
+        $this->data = array_values($this->data);
     }
 
     /**

--- a/Math/VectorOp.php
+++ b/Math/VectorOp.php
@@ -54,7 +54,7 @@ class Math_VectorOp
      * @param   object  $obj
      * @return  boolean true on success
      */
-    public static function isVector2(Math_Vector2 $obj)
+    public static function isVector2(Math_Vector $obj)
     {
         if (function_exists("is_a")) {
             return (is_object($obj) && is_a($obj, "Math_Vector2"));
@@ -71,7 +71,7 @@ class Math_VectorOp
      *
      * @return  boolean true on success
      */
-    public static function isVector3(Math_Vector3 $obj)
+    public static function isVector3(Math_Vector $obj)
     {
         if (function_exists("is_a")) {
             return (is_object($obj) && is_a($obj, "Math_Vector3"));

--- a/tests/Math_VectorTest.php
+++ b/tests/Math_VectorTest.php
@@ -47,6 +47,10 @@ class Math_VectorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(Math_VectorOp::isVector3($this->x) && $this->x->isValid());
 	}
 
+	function testDotProduct() {
+		$this->assertEquals(2, Math_VectorOp::dotProduct($this->x, $this->x));
+	}
+
 	function testBadVector() {
 		try {
             new Math_Vector("foo");


### PR DESCRIPTION
when calculating dotProduct of two 3d vectors, the call to isVector2 would result in a Catchable Fatal Error because of the typehint
this bug has been fixed and a new testcase for this situation has been added