### PR TITLE
fixed require_once paths (see commit 4980a29)

### DIFF
--- a/Math/VectorOp.php
+++ b/Math/VectorOp.php
@@ -218,7 +218,7 @@ class Math_VectorOp
      *
      * @see     isVector()
      */
-    public function multiply(Math_Vector $v1, Math_Vector $v2)
+    public static function multiply(Math_Vector $v1, Math_Vector $v2)
     {
         if (Math_VectorOp::isVector($v1) && Math_VectorOp::isVector($v2)) {
             $n = $v1->size();

--- a/examples/tuple_creation.php
+++ b/examples/tuple_creation.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once "Math/Vector/Tuple.php";
+require_once "Math/Tuple.php";
 
 echo "Creating tuple\n";
 $t = new Math_Tuple(array(2,3,4));

--- a/examples/vector_creation.php
+++ b/examples/vector_creation.php
@@ -40,11 +40,10 @@ $y = new Math_Vector2(array(1,3));
 echo $y->toString()."\n";
 
 echo "==\nInvalid vector\n";
-$bar = new Math_Vector("foo");
-if ($bar->isValid())
-    echo "bar is good\n";
-else
+try {
+    $bar = new Math_Vector("foo");
+} catch (Exception $e) {
     echo "bar is bad\n";
-print_r($bar);
+}
 
 ?>

--- a/examples/vector_creation.php
+++ b/examples/vector_creation.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once "Math/Vector/Vector.php";
-require_once "Math/Vector/Vector2.php";
-require_once "Math/Vector/Vector3.php";
+require_once "Math/Vector.php";
+require_once "Math/Vector2.php";
+require_once "Math/Vector3.php";
 
 $a = range(2,4);
 $t = new Math_Tuple(array(2,6,8));
@@ -42,9 +42,9 @@ echo $y->toString()."\n";
 echo "==\nInvalid vector\n";
 $bar = new Math_Vector("foo");
 if ($bar->isValid())
-	echo "bar is good\n";
+    echo "bar is good\n";
 else
-	echo "bar is bad\n";
+    echo "bar is bad\n";
 print_r($bar);
 
 ?>

--- a/examples/vector_operations.php
+++ b/examples/vector_operations.php
@@ -1,9 +1,9 @@
 <?php
 
-require_once "Math/Vector/Vector.php";
-require_once "Math/Vector/Vector2.php";
-require_once "Math/Vector/Vector3.php";
-require_once "Math/Vector/VectorOp.php";
+require_once "Math/Vector.php";
+require_once "Math/Vector2.php";
+require_once "Math/Vector3.php";
+require_once "Math/VectorOp.php";
 
 $v1 = new Math_Vector2(array(1,2));
 $v2 = new Math_Vector2(array(2,4));


### PR DESCRIPTION
The example files need an adjustment to the directory structure created 14 years ago (compare to commit 4980a29 by CloCkWeRX).

These fixes make the old examples executable (tested cli php5.6 and php8.3). 